### PR TITLE
## 6.1.1 - 2024-10-11

### DIFF
--- a/Buildenator/Configuration/Contract/IEntityToBuild.cs
+++ b/Buildenator/Configuration/Contract/IEntityToBuild.cs
@@ -6,11 +6,11 @@ namespace Buildenator.Configuration.Contract
 {
     internal interface IEntityToBuild : IAdditionalNamespacesProvider
     {
-        IReadOnlyDictionary<string, TypedSymbol> ConstructorParameters { get; }
+        EntityToBuild.Constructor? ConstructorToBuild { get; }
         string FullName { get; }
         string FullNameWithConstraints { get; }
         string Name { get; }
-        IEnumerable<TypedSymbol> SettableProperties { get; }
+        IReadOnlyList<TypedSymbol> SettableProperties { get; }
 
         IReadOnlyList<ITypedSymbol> GetAllUniqueReadOnlyPropertiesWithoutConstructorsParametersMatch();
         IReadOnlyList<ITypedSymbol> GetAllUniqueSettablePropertiesAndParameters();

--- a/Buildenator/Configuration/EntityToBuild.cs
+++ b/Buildenator/Configuration/EntityToBuild.cs
@@ -13,9 +13,9 @@ namespace Buildenator.Configuration
         public string Name { get; }
         public string FullName { get; }
         public string FullNameWithConstraints { get; }
-        public IReadOnlyDictionary<string, TypedSymbol> ConstructorParameters { get; }
-        public IEnumerable<TypedSymbol> SettableProperties { get; }
-        public IEnumerable<TypedSymbol> ReadOnlyProperties { get; }
+        public Constructor? ConstructorToBuild { get; }
+        public IReadOnlyList<TypedSymbol> SettableProperties { get; }
+        public IReadOnlyList<TypedSymbol> ReadOnlyProperties { get; }
         public string[] AdditionalNamespaces { get; }
 
         public EntityToBuild(INamedTypeSymbol typeForBuilder, IMockingProperties? mockingConfiguration, IFixtureProperties? fixtureConfiguration)
@@ -39,43 +39,64 @@ namespace Buildenator.Configuration
             FullName = entityToBuildSymbol.ToDisplayString(new SymbolDisplayFormat(genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters, typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces));
             FullNameWithConstraints = entityToBuildSymbol.ToDisplayString(new SymbolDisplayFormat(
                 genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters | SymbolDisplayGenericsOptions.IncludeTypeConstraints | SymbolDisplayGenericsOptions.IncludeVariance));
-            _mockingConfiguration = mockingConfiguration;
-            _fixtureConfiguration = fixtureConfiguration;
-            ConstructorParameters = GetConstructorParameters(entityToBuildSymbol);
+            ConstructorToBuild = Constructor.CreateConstructorOrDefault(entityToBuildSymbol, mockingConfiguration, fixtureConfiguration);
             (SettableProperties, ReadOnlyProperties) = DividePropertiesBySetability(entityToBuildSymbol, mockingConfiguration, fixtureConfiguration?.Strategy);
         }
 
         public IReadOnlyList<ITypedSymbol> GetAllUniqueSettablePropertiesAndParameters()
         {
+            if (ConstructorToBuild is null)
+            {
+                return _uniqueTypedSymbols ??= SettableProperties;
+            }
+
             return _uniqueTypedSymbols ??= SettableProperties
-                .Where(x => !ConstructorParameters.ContainsKey(x.SymbolName))
-                .Concat(ConstructorParameters.Values).ToList();
+                .Where(x => !ConstructorToBuild.ContainsParameter(x.SymbolName))
+                .Concat(ConstructorToBuild.Parameters).ToList();
         }
 
         public IReadOnlyList<ITypedSymbol> GetAllUniqueReadOnlyPropertiesWithoutConstructorsParametersMatch()
         {
-            return _uniqueReadOnlyTypedSymbols ??= ReadOnlyProperties
-                .Where(x => !ConstructorParameters.ContainsKey(x.SymbolName)).ToList();
-        }
+            if (ConstructorToBuild is null)
+            {
+                return _uniqueReadOnlyTypedSymbols ??= ReadOnlyProperties;
+            }
 
-        private IReadOnlyDictionary<string, TypedSymbol> GetConstructorParameters(INamedTypeSymbol entityToBuildSymbol)
-        {
-            return entityToBuildSymbol.Constructors.OrderByDescending(x => x.Parameters.Length).First().Parameters
-                .ToDictionary(x => x.PascalCaseName(), s => new TypedSymbol(s, _mockingConfiguration, _fixtureConfiguration?.Strategy));
+            return _uniqueReadOnlyTypedSymbols ??= ReadOnlyProperties
+                .Where(x => !ConstructorToBuild.ContainsParameter(x.SymbolName)).ToList();
         }
 
         private static (TypedSymbol[] Settable, TypedSymbol[] ReadOnly) DividePropertiesBySetability(
             INamedTypeSymbol entityToBuildSymbol, IMockingProperties? mockingConfiguration, FixtureInterfacesStrategy? fixtureConfiguration)
         {
-	        var (settable, readOnly) = entityToBuildSymbol.DividePublicPropertiesBySetability();
-	        return (
+            var (settable, readOnly) = entityToBuildSymbol.DividePublicPropertiesBySetability();
+            return (
                 settable.Select(a => new TypedSymbol(a, mockingConfiguration, fixtureConfiguration)).ToArray(),
                 readOnly.Select(a => new TypedSymbol(a, mockingConfiguration, fixtureConfiguration)).ToArray());
         }
 
         private IReadOnlyList<TypedSymbol>? _uniqueTypedSymbols;
         private IReadOnlyList<TypedSymbol>? _uniqueReadOnlyTypedSymbols;
-        private readonly IMockingProperties? _mockingConfiguration;
-        private readonly IFixtureProperties? _fixtureConfiguration;
+
+        internal sealed class Constructor
+        {
+            public static Constructor? CreateConstructorOrDefault(
+                INamedTypeSymbol entityToBuildSymbol,
+                IMockingProperties? mockingConfiguration,
+                IFixtureProperties? fixtureConfiguration)
+                => entityToBuildSymbol.Constructors.Length > 0
+                ? new Constructor(entityToBuildSymbol.Constructors.OrderByDescending(x => x.Parameters.Length).First().Parameters
+                    .ToDictionary(x => x.PascalCaseName(), s => new TypedSymbol(s, mockingConfiguration, fixtureConfiguration?.Strategy)))
+                : default;
+            private Constructor(IReadOnlyDictionary<string, TypedSymbol> constructorParameters)
+            {
+                ConstructorParameters = constructorParameters;
+            }
+
+            public IReadOnlyDictionary<string, TypedSymbol> ConstructorParameters { get; }
+
+            public bool ContainsParameter(string parameterName) => ConstructorParameters.ContainsKey(parameterName);
+            public IEnumerable<TypedSymbol> Parameters => ConstructorParameters.Values;
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Removed
 
-## 6.1.0 - 2023-11-10
+## 6.1.1 & 8.1.1 - 2024-10-11
+
+### Changed
+
+- Fixing code generation for the scenario with an entity having only private constructors. For now it will not generate automatically the build methods.
+   - In other words, an user must define their own Build method without parameters returning the entity. In the future, more meaningful error will be added.
+
+## 6.1.0 & 8.1.0 - 2024-01-05
 
 ### Changed
 

--- a/Tests/Buildenator.IntegrationTests.SharedEntities/EntityWithPrivateConstructor.cs
+++ b/Tests/Buildenator.IntegrationTests.SharedEntities/EntityWithPrivateConstructor.cs
@@ -1,0 +1,17 @@
+﻿using Buildenator.IntegrationTests.SharedEntities.DifferentNamespace;
+
+namespace Buildenator.IntegrationTests.SharedEntities;
+
+public class EntityWithPrivateConstructor
+{
+    private EntityWithPrivateConstructor(int propertyIntGetter, string propertyStringGetter, EntityInDifferentNamespace entityInDifferentNamespace)
+    {
+            PropertyIntGetter = propertyIntGetter;
+            PropertyGetter = propertyStringGetter;
+            EntityInDifferentNamespace = entityInDifferentNamespace;
+        }
+
+    public int PropertyIntGetter { get; }
+    public string PropertyGetter { get; }
+    public EntityInDifferentNamespace EntityInDifferentNamespace { get; }
+}

--- a/Tests/Buildenator.IntegrationTests.Source/Builders/EntityWithPrivateConstructorBuilder.cs
+++ b/Tests/Buildenator.IntegrationTests.Source/Builders/EntityWithPrivateConstructorBuilder.cs
@@ -1,0 +1,13 @@
+﻿using Buildenator.Abstraction;
+using Buildenator.IntegrationTests.SharedEntities;
+
+namespace Buildenator.IntegrationTests.Source.Builders;
+
+[MakeBuilder(typeof(EntityWithPrivateConstructor))]
+public partial class EntityWithPrivateConstructorBuilder
+{
+    public EntityWithPrivateConstructor Build()
+    {
+        return default!;
+    }
+}

--- a/Tests/Buildenator.UnitTests/Configuration/BuilderPropertiesTests.cs
+++ b/Tests/Buildenator.UnitTests/Configuration/BuilderPropertiesTests.cs
@@ -95,7 +95,7 @@ public class BuilderPropertiesTests
     {
         // Arrange
         var typeSymbolMock = new Mock<INamedTypeSymbol>();
-        var attributeDataMock = new MakeBuilderAttributeInternal(typeSymbolMock.Object, prefix, false, NullableStrategy.Enabled, false, true);
+        var attributeDataMock = GenerateAttributeInternal(typeSymbolMock, prefix);
 
         var methodSymbolMock = new Mock<IMethodSymbol>();
         methodSymbolMock.SetupGet(x => x.Name).Returns($"{prefix}Method");
@@ -122,7 +122,7 @@ public class BuilderPropertiesTests
     {
         // Arrange
         var typeSymbolMock = new Mock<INamedTypeSymbol>();
-        var attributeDataMock = new MakeBuilderAttributeInternal(typeSymbolMock.Object, "Build", false, NullableStrategy.Enabled, false, true);
+        var attributeDataMock = GenerateAttributeInternal(typeSymbolMock);
 
         var methodSymbolMock = new Mock<IMethodSymbol>();
         methodSymbolMock.SetupGet(x => x.Name).Returns(DefaultConstants.PostBuildMethodName);
@@ -142,7 +142,7 @@ public class BuilderPropertiesTests
     {
         // Arrange
         var typeSymbolMock = new Mock<INamedTypeSymbol>();
-        var attributeDataMock = new MakeBuilderAttributeInternal(typeSymbolMock.Object, "Build", false, NullableStrategy.Enabled, false, true);
+        var attributeDataMock = GenerateAttributeInternal(typeSymbolMock);
 
         var methodSymbolMock = new Mock<IMethodSymbol>();
         methodSymbolMock.SetupGet(x => x.MethodKind).Returns(MethodKind.Constructor);
@@ -164,7 +164,7 @@ public class BuilderPropertiesTests
     {
         // Arrange
         var typeSymbolMock = new Mock<INamedTypeSymbol>();
-        var attributeDataMock = new MakeBuilderAttributeInternal(typeSymbolMock.Object, "Build", false, NullableStrategy.Enabled, false, true);
+        var attributeDataMock = GenerateAttributeInternal(typeSymbolMock);
 
         var methodSymbolMock = new Mock<IMethodSymbol>();
         methodSymbolMock.SetupGet(x => x.MethodKind).Returns(MethodKind.Constructor);
@@ -186,7 +186,7 @@ public class BuilderPropertiesTests
     {
         // Arrange
         var typeSymbolMock = new Mock<INamedTypeSymbol>();
-        var attributeDataMock = new MakeBuilderAttributeInternal(typeSymbolMock.Object, "Build", false, NullableStrategy.Enabled, false, true);
+        var attributeDataMock = GenerateAttributeInternal(typeSymbolMock);
 
         var fieldSymbolMock = new Mock<IFieldSymbol>();
         fieldSymbolMock.SetupGet(x => x.Name).Returns("SomeField");
@@ -199,4 +199,7 @@ public class BuilderPropertiesTests
         // Assert
         properties.Fields.Should().ContainKey(fieldSymbolMock.Object.Name).And.ContainValue(fieldSymbolMock.Object);
     }
+
+    private static MakeBuilderAttributeInternal GenerateAttributeInternal(Mock<INamedTypeSymbol> typeSymbolMock, string prefix = "Build")
+        => new (typeSymbolMock.Object, prefix, false, NullableStrategy.Enabled, false, true);
 }


### PR DESCRIPTION
### Changed

- Fixing code generation for the scenario with an entity having only private constructors. For now it will not generate automatically the build methods.
   - In other words, an user must define their own Build method without parameters returning the entity. In the future, more meaningful error will be added.