### PR TITLE
## 8.2.1.0 - 2024-10-30

### DIFF
--- a/Buildenator/Buildenator.csproj
+++ b/Buildenator/Buildenator.csproj
@@ -9,7 +9,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <!-- Do not include the generator as a lib dependency -->
-	<Version>8.2.0</Version>
+	<Version>8.2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [x.x.x]
+## [MinDotNetVersion.x.x.x]
 
 ### Added
 ### Changed
 ### Removed
+
+## 8.2.1.0 - 2024-10-30
+
+### Changed
+- Fixed the default nullable strategy - it should inherit the option from the project the builder is in.
+   - *Warning* It may be a breaking change if someone is accustomed to previous behavior, but it was a bug.
+- Changed the format of versioning: The biggest number is only to reflect minimum version of .net. The rest is like in the Semantic Versioning
 
 ## 8.2.0 - 2024-10-23
 

--- a/Tests/Buildenator.IntegrationTests.SourceNullable/Builders/ChildEntityBuilder.cs
+++ b/Tests/Buildenator.IntegrationTests.SourceNullable/Builders/ChildEntityBuilder.cs
@@ -4,7 +4,7 @@ using Buildenator.IntegrationTests.SharedEntitiesNullable;
 
 namespace Buildenator.IntegrationTests.SourceNullable.Builders
 {
-    [MakeBuilder(typeof(ChildEntity))]
+    [MakeBuilder(typeof(ChildEntity), nullableStrategy: NullableStrategy.Default)]
     [MoqConfiguration(MockingInterfacesStrategy.All)]
     public partial class ChildEntityBuilder
     {

--- a/Tests/Buildenator.IntegrationTests/BuildersGeneratorTests.cs
+++ b/Tests/Buildenator.IntegrationTests/BuildersGeneratorTests.cs
@@ -5,6 +5,7 @@ using Buildenator.IntegrationTests.SharedEntities.DifferentNamespace;
 using FluentAssertions;
 using Xunit;
 using PostBuildEntityBuilder = Buildenator.IntegrationTests.Source.Builders.PostBuildEntityBuilder;
+using Newtonsoft.Json.Linq;
 
 namespace Buildenator.IntegrationTests;
 


### PR DESCRIPTION
### Changed
- Fixed the default nullable strategy - it should inherit the option from the project the builder is in.
   - *Warning* It may be a breaking change if someone is accustomed to previous behavior, but it was a bug.
- Changed the format of versioning: The biggest number is only to reflect minimum version of .net. The rest is like in the Semantic Versioning